### PR TITLE
[front] PortfolioPage 컴포넌트 파일 추가

### DIFF
--- a/front/.prettierrc.json
+++ b/front/.prettierrc.json
@@ -1,6 +1,6 @@
 {
-    "trailingComma": "es5",
-    "tabWidth": 2,
-    "semi": false,
-    "singleQuote": true
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true
 }

--- a/front/src/App.test.tsx
+++ b/front/src/App.test.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import App from './App'
 
 test('성능 테스트', () => {
-  render(<App />);
+  render(<App />)
   // // Act: try to find the expected link.
   // const linkElement = screen.getByText(/learn react/i);
   // // Assert: check that required link is indeed in the document.
   // expect(linkElement).toBeInTheDocument();
-});
+})

--- a/front/src/pages/myportfolio/MyportfolioPage.tsx
+++ b/front/src/pages/myportfolio/MyportfolioPage.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 
 function MyportfolioPage() {
-    return (
-        <div>
-            <p>MyportfolioPage</p>
-        </div>
-    )
+  return (
+    <div>
+      <p>MyportfolioPage</p>
+    </div>
+  )
 }
 
 export default MyportfolioPage

--- a/front/src/pages/portfolio/PortfolioPage.tsx
+++ b/front/src/pages/portfolio/PortfolioPage.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 
 function PortfolioPage() {
-    return (
-        <div>
-            <p>PortfolioPage</p>
-        </div>
-    )
+  return (
+    <div>
+      <p>PortfolioPage</p>
+    </div>
+  )
 }
 
 export default PortfolioPage

--- a/front/src/pages/portfolio/components/DesignRecommendBar.tsx
+++ b/front/src/pages/portfolio/components/DesignRecommendBar.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/PortfolioItemBar.tsx
+++ b/front/src/pages/portfolio/components/PortfolioItemBar.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/PortfolioWithDesign.tsx
+++ b/front/src/pages/portfolio/components/PortfolioWithDesign.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemdesigns/base/ActivitiesDesign.tsx
+++ b/front/src/pages/portfolio/components/itemdesigns/base/ActivitiesDesign.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemdesigns/base/AwardsDesign.tsx
+++ b/front/src/pages/portfolio/components/itemdesigns/base/AwardsDesign.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemdesigns/base/CareerDesign.tsx
+++ b/front/src/pages/portfolio/components/itemdesigns/base/CareerDesign.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemdesigns/base/CoverDesign.tsx
+++ b/front/src/pages/portfolio/components/itemdesigns/base/CoverDesign.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemdesigns/base/CoverletterDesign.tsx
+++ b/front/src/pages/portfolio/components/itemdesigns/base/CoverletterDesign.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemdesigns/base/EducationDesign.tsx
+++ b/front/src/pages/portfolio/components/itemdesigns/base/EducationDesign.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemdesigns/base/InfoDesigns.tsx
+++ b/front/src/pages/portfolio/components/itemdesigns/base/InfoDesigns.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemdesigns/base/ProjectDesign.tsx
+++ b/front/src/pages/portfolio/components/itemdesigns/base/ProjectDesign.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/ActivitiesForm.tsx
+++ b/front/src/pages/portfolio/components/itemforms/ActivitiesForm.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/AwardsForm.tsx
+++ b/front/src/pages/portfolio/components/itemforms/AwardsForm.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/CareerForm.tsx
+++ b/front/src/pages/portfolio/components/itemforms/CareerForm.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/CoverForm.tsx
+++ b/front/src/pages/portfolio/components/itemforms/CoverForm.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/CoverletterForm.tsx
+++ b/front/src/pages/portfolio/components/itemforms/CoverletterForm.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/EducationForm.tsx
+++ b/front/src/pages/portfolio/components/itemforms/EducationForm.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/InfoForm.tsx
+++ b/front/src/pages/portfolio/components/itemforms/InfoForm.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/ProjectForm.tsx
+++ b/front/src/pages/portfolio/components/itemforms/ProjectForm.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentCalendar.tsx
+++ b/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentCalendar.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentCheckbox.tsx
+++ b/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentCheckbox.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentDropdown.tsx
+++ b/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentDropdown.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentImgUpload.tsx
+++ b/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentImgUpload.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentInputLong.tsx
+++ b/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentInputLong.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentInputShort.tsx
+++ b/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentInputShort.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentTextareaLong.tsx
+++ b/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentTextareaLong.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentTextareaShort.tsx
+++ b/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentTextareaShort.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentUploadFile.tsx
+++ b/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentUploadFile.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemTitle.tsx
+++ b/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemTitle.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemTitleDropdown.tsx
+++ b/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemTitleDropdown.tsx
@@ -1,0 +1,1 @@
+export default {}

--- a/front/src/setupTests.tsx
+++ b/front/src/setupTests.tsx
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom'

--- a/front/src/store/portfolioState.ts
+++ b/front/src/store/portfolioState.ts
@@ -1,0 +1,1 @@
+export default {}

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -1,21 +1,21 @@
 {
-    "compilerOptions": {
-        "target": "es6",
-        "lib": ["dom", "dom.iterable", "esnext"],
-        "baseUrl": "./src",
-        "allowJs": true,
-        "skipLibCheck": true,
-        "esModuleInterop": true,
-        "allowSyntheticDefaultImports": true,
-        "strict": true,
-        "forceConsistentCasingInFileNames": false,
-        "noFallthroughCasesInSwitch": true,
-        "module": "esnext",
-        "moduleResolution": "node",
-        "resolveJsonModule": true,
-        "isolatedModules": true,
-        "noEmit": true,
-        "jsx": "react-jsx"
-    },
-    "include": ["src"]
+  "compilerOptions": {
+    "target": "es6",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "baseUrl": "./src",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": false,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
## 📋 상세 구현 내용
- 프론트 프로젝트 설계 기반 PortfolioPage 파일 생성 
- 실행 시 ESLint 에러 나지 않도록 파일 내부에 간단한 기본 코드 작성
- prettier 2 칸 전 파일에 적용

## 📌 전달 사항
- .prettier.json 설정 사항이 ts 파일에는 적용되지 않는 듯 하니, VSC 내부 prettier 설정이 2 칸인지 확인해주세요

## 🪡 연관 이슈
- resolve : #28 
- related to : #26 #5 
