### PR TITLE
[front] 포트폴리오 항목 사이드바

### DIFF
--- a/front/src/pages/portfolio/PortfolioPage.tsx
+++ b/front/src/pages/portfolio/PortfolioPage.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
+import PorfolioItemBar from './components/PortfolioItemBar'
 
 function PortfolioPage() {
   return (
     <div>
-      <p>PortfolioPage</p>
+      <PorfolioItemBar />
     </div>
   )
 }

--- a/front/src/pages/portfolio/components/PortfolioItemBar.tsx
+++ b/front/src/pages/portfolio/components/PortfolioItemBar.tsx
@@ -1,1 +1,77 @@
-export default {}
+/* eslint react/no-array-index-key: 0 */
+
+import React, { useState } from 'react'
+import { useRecoilState } from 'recoil'
+
+// atom 과 selector import
+import { pfItemsOrderState } from 'store/portfolioState'
+// 사용할 type import
+import { PorfolioItemsType } from 'store/portfolioType'
+
+function PortfolioItemBar() {
+  // 인덱스 순서가 담긴 atom과 selector을 선언
+  const [pfItemsOrder, setPfItemsOrder] = useRecoilState(pfItemsOrderState)
+
+  /** 순서 바뀌는 함수
+   * 최종 저장 버튼 때 type order 프로퍼티로 순서 저장해두면 된다
+   * 상세 페이지서 조회시 : 순서대로 sort 해서 띄우기
+   * */
+  const changeOrder = (num1: number, num2: number) => {
+    // 변경할 인덱스 배열 복사
+    const changePfItems = [...pfItemsOrder]
+    ;[changePfItems[num1], changePfItems[num2]] = [
+      changePfItems[num2],
+      changePfItems[num1],
+    ]
+    setPfItemsOrder(changePfItems)
+  }
+
+  // 드래그 시 선택된 항목의 index
+  const [isSelected, setIsSelected] = useState<number>(0)
+
+  // 드래그 dnd 함수
+  const dragFunction = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    e.dataTransfer.effectAllowed = 'move'
+  }
+
+  const dropFunction = (
+    e: React.DragEvent<HTMLDivElement>,
+    idx: number,
+    selectedIdx: number
+  ) => {
+    changeOrder(selectedIdx, idx)
+  }
+
+  const dragStartFunction = (
+    e: React.DragEvent<HTMLDivElement>,
+    idx: number
+  ) => {
+    e.dataTransfer.effectAllowed = 'move'
+    setIsSelected(idx)
+  }
+
+  return (
+    <div>
+      <span>
+        {/* idx 는 고유한 key 값으로 쓰면 안됨 (예외적인 상황 제외) 
+        여기서는 순서가 변경될 때마다 바뀌어야하므로 idx 로 key 값 지정 */}
+        {pfItemsOrder.map((item: PorfolioItemsType, idx) => (
+          <div
+            onDragOver={(event) => dragFunction(event)}
+            onDrop={(event) => dropFunction(event, isSelected, idx)}
+            onDragEnter={(event) => dragFunction(event)}
+            onDragLeave={(event) => dragFunction(event)}
+            onDragStart={(event) => dragStartFunction(event, idx)}
+          >
+            <p key={idx} draggable>
+              {item.mustHave && <span>*</span>}
+              {item.portfolioItems}
+            </p>
+          </div>
+        ))}
+      </span>
+    </div>
+  )
+}
+export default PortfolioItemBar

--- a/front/src/store/portfolioState.ts
+++ b/front/src/store/portfolioState.ts
@@ -1,1 +1,9 @@
-export default {}
+import { atom, selector } from 'recoil'
+
+import { PortfolioItems, PorfolioItemsType } from './portfolioType'
+
+// 포트폴리오 항목 순서 state
+export const pfItemsOrderState = atom<Array<PorfolioItemsType>>({
+  key: 'pfItemsOrderState',
+  default: PortfolioItems,
+})

--- a/front/src/store/portfolioType.ts
+++ b/front/src/store/portfolioType.ts
@@ -1,61 +1,66 @@
 // 포트폴리오 항목 - 인덱스 연결 type
 export interface PorfolioItemsType {
-  portfolioItems: string
+  portfolioItems: number
   mustHave: boolean
-  order: number
 }
 
 // 포트폴리오 항목 Enum
 export enum PortfoiloItemsEnum {
-  COVER = '표지',
-  INFO = '기본정보',
-  EDUCATION = '학력',
-  PROJECT = '프로젝트',
-  ACTIVITIES = '대내외 활동',
-  AWARDS = '수상내역',
-  CAREER = '경력',
-  COVERLETTER = '자기소개서',
+  COVER = 1,
+  INFO,
+  EDUCATION,
+  PROJECT,
+  ACTIVITIES,
+  AWARDS,
+  CAREER,
+  COVERLETTER,
 }
+
+// 포트폴리오 항목 문자열
+// enum 이 1부터 시작하기 때문에 맨 앞에 빈 문자열 추가
+export const PortfolioItemsStr = [
+  '',
+  '표지',
+  '기본정보',
+  '학력',
+  '프로젝트',
+  '대내외활동',
+  '수상내역',
+  '경력',
+  '자기소개서',
+]
 
 export const PortfolioItems: PorfolioItemsType[] = [
   {
     portfolioItems: PortfoiloItemsEnum.COVER,
     mustHave: true,
-    order: 0,
   },
   {
     portfolioItems: PortfoiloItemsEnum.INFO,
     mustHave: true,
-    order: 1,
   },
   {
     portfolioItems: PortfoiloItemsEnum.EDUCATION,
     mustHave: true,
-    order: 2,
   },
   {
     portfolioItems: PortfoiloItemsEnum.PROJECT,
     mustHave: false,
-    order: 3,
   },
   {
     portfolioItems: PortfoiloItemsEnum.ACTIVITIES,
     mustHave: false,
-    order: 4,
   },
   {
     portfolioItems: PortfoiloItemsEnum.AWARDS,
     mustHave: false,
-    order: 5,
   },
   {
     portfolioItems: PortfoiloItemsEnum.CAREER,
     mustHave: false,
-    order: 6,
   },
   {
     portfolioItems: PortfoiloItemsEnum.COVERLETTER,
     mustHave: false,
-    order: 7,
   },
 ]

--- a/front/src/store/portfolioType.ts
+++ b/front/src/store/portfolioType.ts
@@ -1,0 +1,61 @@
+// 포트폴리오 항목 - 인덱스 연결 type
+export interface PorfolioItemsType {
+  portfolioItems: string
+  mustHave: boolean
+  order: number
+}
+
+// 포트폴리오 항목 Enum
+export enum PortfoiloItemsEnum {
+  COVER = '표지',
+  INFO = '기본정보',
+  EDUCATION = '학력',
+  PROJECT = '프로젝트',
+  ACTIVITIES = '대내외 활동',
+  AWARDS = '수상내역',
+  CAREER = '경력',
+  COVERLETTER = '자기소개서',
+}
+
+export const PortfolioItems: PorfolioItemsType[] = [
+  {
+    portfolioItems: PortfoiloItemsEnum.COVER,
+    mustHave: true,
+    order: 0,
+  },
+  {
+    portfolioItems: PortfoiloItemsEnum.INFO,
+    mustHave: true,
+    order: 1,
+  },
+  {
+    portfolioItems: PortfoiloItemsEnum.EDUCATION,
+    mustHave: true,
+    order: 2,
+  },
+  {
+    portfolioItems: PortfoiloItemsEnum.PROJECT,
+    mustHave: false,
+    order: 3,
+  },
+  {
+    portfolioItems: PortfoiloItemsEnum.ACTIVITIES,
+    mustHave: false,
+    order: 4,
+  },
+  {
+    portfolioItems: PortfoiloItemsEnum.AWARDS,
+    mustHave: false,
+    order: 5,
+  },
+  {
+    portfolioItems: PortfoiloItemsEnum.CAREER,
+    mustHave: false,
+    order: 6,
+  },
+  {
+    portfolioItems: PortfoiloItemsEnum.COVERLETTER,
+    mustHave: false,
+    order: 7,
+  },
+]


### PR DESCRIPTION
## 📋 상세 구현 내용
- 포트폴리오 항목바 드래그 앤 드롭 기능 구현
- 항목별 순서 type 과 순서를 변경하는 atom 생성

## 📌 전달 사항
- 포트폴리오 상세 페이지 조회 시 순서를 저장한 대로 띄울 수 있게 atom 추가 필요

## 🪡 연관 이슈
- resolve : #39 
