### PR TITLE
[front] 포트폴리오 항목 바와 타 컴포넌트 순서 연결

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -2,11 +2,7 @@ import React from 'react'
 import './App.css'
 
 function App() {
-  return (
-    <div>
-      <h1>Hello World!</h1>
-    </div>
-  )
+  return <div />
 }
 
 export default App

--- a/front/src/api/authApi.ts
+++ b/front/src/api/authApi.ts
@@ -1,4 +1,1 @@
-import { LoginType } from 'store/type'
-import { GET, POST, PUT } from './api'
-
-export const login = (url: string, body: LoginType) => POST(url, body)
+export default {}

--- a/front/src/components/NavBar.tsx
+++ b/front/src/components/NavBar.tsx
@@ -1,96 +1,18 @@
 import React, { useState, ComponentProps } from 'react'
 import { Link } from 'react-router-dom'
 
-// atom 을 사용하기 위해 recoil 라이브러리 import
-import { useRecoilState } from 'recoil'
-
-// 사용할 atom 과 type import
-import { menuState } from 'store/state'
-import { Menu } from 'store/type'
-
-// 로그인 api, url import
-import { login } from 'api/authApi'
-import { loginUrl } from 'api/url'
-
 function NavBar() {
-  /**
-   * 이제 메뉴를 클릭할 때마다 atom 값을 바꿔서 색을 바꿔볼 겁니다
-   *
-   * 우선, useRecoilState 로 atom 값과 atom 값을 바꿀 수 있도록 만듭니다
-   * 그 후, 클릭 시 색이 바뀌게 (atom 값이 변경되도록) 하고 싶으므로
-   * onClick 이벤트에 setMenuColor 로 색을 바꿔줍니다
-   *
-   * 이 때, Menu 는 지정해 둔 enum 타입입니다
-   * 실제로 누를 때마다 atom 값이 변경되며 색이 바뀌는 걸 확인할 수 있습니다
-   */
-  const [menuColor, setMenuColor] = useRecoilState(menuState)
-  const tempStyle = {
-    width: '300px',
-    height: '100px',
-    background: menuColor,
-  }
-
-  // 로그인 테스트 코드를 위한 상태 지정
-  const [token, setToken] = useState('')
-
-  const [myid, setMyId] = useState('')
-  const [mypw, setMyPw] = useState('')
-
-  const onIdHandler: ComponentProps<'input'>['onChange'] = (event) => {
-    setMyId(event.currentTarget.value)
-  }
-  const onPwHandler: ComponentProps<'input'>['onChange'] = (event) => {
-    setMyPw(event.currentTarget.value)
-  }
-
-  const onSubmitHandler = (event: React.FormEvent) => {
-    // 버튼만 누르면 리프레시 되는것을 막아준다
-    event.preventDefault()
-    const body = {
-      id: myid,
-      pw: mypw,
-    }
-    const getData = () =>
-      login(loginUrl, body).then((data) => {
-        console.log(data)
-        setToken(data.token)
-      })
-    getData()
-    setMyId('')
-    setMyPw('')
-  }
-
   return (
     <div>
-      {/* atom 사용법 (임시) */}
-      <div style={tempStyle} />
-      <Link to="/" onClick={() => setMenuColor(Menu.HOME)}>
-        <h1>홈</h1>
+      <Link to="/">
+        <h3>홈</h3>
       </Link>
-      <Link to="/portfolio" onClick={() => setMenuColor(Menu.PORTFOLIO)}>
-        <h1>포트폴리오 만들기</h1>
+      <Link to="/portfolio">
+        <h3>포트폴리오 만들기</h3>
       </Link>
-      <Link to="/myportfolio" onClick={() => setMenuColor(Menu.MYPORTFOLIO)}>
-        <h1>내 포트폴리오</h1>
+      <Link to="/myportfolio">
+        <h3>내 포트폴리오</h3>
       </Link>
-
-      {/* 로그인 폼 (임시) */}
-
-      <p>MainPage</p>
-      <form onSubmit={onSubmitHandler}>
-        <input value={myid} placeholder="아이디 입력" onChange={onIdHandler} />
-        <input
-          value={mypw}
-          placeholder="비밀번호 입력"
-          onChange={onPwHandler}
-        />
-        <br />
-        <button type="submit" formAction="">
-          로그인
-        </button>
-      </form>
-
-      <p>{token}</p>
     </div>
   )
 }

--- a/front/src/pages/portfolio/PortfolioPage.tsx
+++ b/front/src/pages/portfolio/PortfolioPage.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import PorfolioItemBar from './components/PortfolioItemBar'
+import PortfolioWithDesign from './components/PortfolioWithDesign'
 
 function PortfolioPage() {
   return (
-    <div>
+    <div style={{ display: 'flex' }}>
       <PorfolioItemBar />
+      <PortfolioWithDesign />
     </div>
   )
 }

--- a/front/src/pages/portfolio/components/PortfolioItemBar.tsx
+++ b/front/src/pages/portfolio/components/PortfolioItemBar.tsx
@@ -66,7 +66,7 @@ function PortfolioItemBar() {
           >
             <p key={idx} draggable>
               {item.mustHave && <span>*</span>}
-              {item.portfolioItems}
+              {item.itemTitle}
             </p>
           </div>
         ))}

--- a/front/src/pages/portfolio/components/PortfolioWithDesign.tsx
+++ b/front/src/pages/portfolio/components/PortfolioWithDesign.tsx
@@ -1,1 +1,32 @@
-export default {}
+/* eslint react/no-array-index-key: 0 */
+
+import React, { useState } from 'react'
+import { useRecoilState } from 'recoil'
+
+// atom 과 selector import
+import { pfItemsOrderState } from 'store/portfolioState'
+// 사용할 type import
+import { PorfolioItemsType } from 'store/portfolioType'
+
+function PortfolioWithDesign() {
+  // 인덱스 순서가 담긴 atom과 selector을 선언
+  const [pfItemsOrder, setPfItemsOrder] = useRecoilState(pfItemsOrderState)
+
+  return (
+    <div>
+      <span>
+        {/* idx 는 고유한 key 값으로 쓰면 안됨 (예외적인 상황 제외) 
+        여기서는 순서가 변경될 때마다 바뀌어야하므로 idx 로 key 값 지정 */}
+        {pfItemsOrder.map((item: PorfolioItemsType, idx) => (
+          <div key={idx}>
+            <item.itemForm />
+            <item.itemDesign />
+            <br />
+          </div>
+        ))}
+      </span>
+    </div>
+  )
+}
+
+export default PortfolioWithDesign

--- a/front/src/pages/portfolio/components/itemdesigns/base/ActivitiesDesign.tsx
+++ b/front/src/pages/portfolio/components/itemdesigns/base/ActivitiesDesign.tsx
@@ -1,1 +1,7 @@
-export default {}
+import React from 'react'
+
+function ActivitiesDesign() {
+  return <div>대내외활동 디자인 폼</div>
+}
+
+export default ActivitiesDesign

--- a/front/src/pages/portfolio/components/itemdesigns/base/AwardsDesign.tsx
+++ b/front/src/pages/portfolio/components/itemdesigns/base/AwardsDesign.tsx
@@ -1,1 +1,7 @@
-export default {}
+import React from 'react'
+
+function AwardsDesign() {
+  return <div>수상내역 디자인 폼</div>
+}
+
+export default AwardsDesign

--- a/front/src/pages/portfolio/components/itemdesigns/base/CareerDesign.tsx
+++ b/front/src/pages/portfolio/components/itemdesigns/base/CareerDesign.tsx
@@ -1,1 +1,7 @@
-export default {}
+import React from 'react'
+
+function CareerDesign() {
+  return <div>경력 디자인 폼</div>
+}
+
+export default CareerDesign

--- a/front/src/pages/portfolio/components/itemdesigns/base/CoverDesign.tsx
+++ b/front/src/pages/portfolio/components/itemdesigns/base/CoverDesign.tsx
@@ -1,1 +1,7 @@
-export default {}
+import React from 'react'
+
+function CoverDesign() {
+  return <div>표지 디자인 폼</div>
+}
+
+export default CoverDesign

--- a/front/src/pages/portfolio/components/itemdesigns/base/CoverletterDesign.tsx
+++ b/front/src/pages/portfolio/components/itemdesigns/base/CoverletterDesign.tsx
@@ -1,1 +1,7 @@
-export default {}
+import React from 'react'
+
+function CoverletterDesign() {
+  return <div>자기소개서 디자인 폼</div>
+}
+
+export default CoverletterDesign

--- a/front/src/pages/portfolio/components/itemdesigns/base/EducationDesign.tsx
+++ b/front/src/pages/portfolio/components/itemdesigns/base/EducationDesign.tsx
@@ -1,1 +1,7 @@
-export default {}
+import React from 'react'
+
+function EducationDesign() {
+  return <div>학력 디자인 폼</div>
+}
+
+export default EducationDesign

--- a/front/src/pages/portfolio/components/itemdesigns/base/InfoDesigns.tsx
+++ b/front/src/pages/portfolio/components/itemdesigns/base/InfoDesigns.tsx
@@ -1,1 +1,7 @@
-export default {}
+import React from 'react'
+
+function InfoDesign() {
+  return <div>기본정보 디자인 폼</div>
+}
+
+export default InfoDesign

--- a/front/src/pages/portfolio/components/itemdesigns/base/ProjectDesign.tsx
+++ b/front/src/pages/portfolio/components/itemdesigns/base/ProjectDesign.tsx
@@ -1,1 +1,7 @@
-export default {}
+import React from 'react'
+
+function ProjectDesign() {
+  return <div>프로젝트 디자인 폼</div>
+}
+
+export default ProjectDesign

--- a/front/src/pages/portfolio/components/itemforms/ActivitiesForm.tsx
+++ b/front/src/pages/portfolio/components/itemforms/ActivitiesForm.tsx
@@ -1,1 +1,7 @@
-export default {}
+import React from 'react'
+
+function ActivitiesForm() {
+  return <div>대내외활동 입력 폼</div>
+}
+
+export default ActivitiesForm

--- a/front/src/pages/portfolio/components/itemforms/AwardsForm.tsx
+++ b/front/src/pages/portfolio/components/itemforms/AwardsForm.tsx
@@ -1,1 +1,7 @@
-export default {}
+import React from 'react'
+
+function AwardsForm() {
+  return <div>수상내역 입력 폼</div>
+}
+
+export default AwardsForm

--- a/front/src/pages/portfolio/components/itemforms/CareerForm.tsx
+++ b/front/src/pages/portfolio/components/itemforms/CareerForm.tsx
@@ -1,1 +1,7 @@
-export default {}
+import React from 'react'
+
+function CareerForm() {
+  return <div>경력 입력 폼</div>
+}
+
+export default CareerForm

--- a/front/src/pages/portfolio/components/itemforms/CoverForm.tsx
+++ b/front/src/pages/portfolio/components/itemforms/CoverForm.tsx
@@ -1,1 +1,7 @@
-export default {}
+import React from 'react'
+
+function CoverForm() {
+  return <div>표지 입력 폼</div>
+}
+
+export default CoverForm

--- a/front/src/pages/portfolio/components/itemforms/CoverletterForm.tsx
+++ b/front/src/pages/portfolio/components/itemforms/CoverletterForm.tsx
@@ -1,1 +1,7 @@
-export default {}
+import React from 'react'
+
+function CoverletterForm() {
+  return <div>자기소개서 입력 폼</div>
+}
+
+export default CoverletterForm

--- a/front/src/pages/portfolio/components/itemforms/EducationForm.tsx
+++ b/front/src/pages/portfolio/components/itemforms/EducationForm.tsx
@@ -1,1 +1,7 @@
-export default {}
+import React from 'react'
+
+function EducationForm() {
+  return <div>학력 입력 폼</div>
+}
+
+export default EducationForm

--- a/front/src/pages/portfolio/components/itemforms/InfoForm.tsx
+++ b/front/src/pages/portfolio/components/itemforms/InfoForm.tsx
@@ -1,1 +1,7 @@
-export default {}
+import React from 'react'
+
+function InfoForm() {
+  return <div>기본정보 입력 폼</div>
+}
+
+export default InfoForm

--- a/front/src/pages/portfolio/components/itemforms/ProjectForm.tsx
+++ b/front/src/pages/portfolio/components/itemforms/ProjectForm.tsx
@@ -1,1 +1,7 @@
-export default {}
+import React from 'react'
+
+function ProjectForm() {
+  return <div>프로젝트 입력 폼</div>
+}
+
+export default ProjectForm

--- a/front/src/store/portfolioType.ts
+++ b/front/src/store/portfolioType.ts
@@ -1,7 +1,31 @@
+// 포트폴리오 디자인 import
+import ActivitiesDesign from 'pages/portfolio/components/itemdesigns/base/ActivitiesDesign'
+import AwardsDesign from 'pages/portfolio/components/itemdesigns/base/AwardsDesign'
+import CareerDesign from 'pages/portfolio/components/itemdesigns/base/CareerDesign'
+import CoverDesign from 'pages/portfolio/components/itemdesigns/base/CoverDesign'
+import CoverletterDesign from 'pages/portfolio/components/itemdesigns/base/CoverletterDesign'
+import EducationDesign from 'pages/portfolio/components/itemdesigns/base/EducationDesign'
+import InfoDesigns from 'pages/portfolio/components/itemdesigns/base/InfoDesigns'
+import ProjectDesign from 'pages/portfolio/components/itemdesigns/base/ProjectDesign'
+
+// 포트폴리오 입력폼 import
+import ActivitiesForm from 'pages/portfolio/components/itemforms/ActivitiesForm'
+import AwardsForm from 'pages/portfolio/components/itemforms/AwardsForm'
+import CareerForm from 'pages/portfolio/components/itemforms/CareerForm'
+import CoverForm from 'pages/portfolio/components/itemforms/CoverForm'
+import CoverletterForm from 'pages/portfolio/components/itemforms/CoverletterForm'
+import EducationForm from 'pages/portfolio/components/itemforms/EducationForm'
+import InfoForm from 'pages/portfolio/components/itemforms/InfoForm'
+import ProjectForm from 'pages/portfolio/components/itemforms/ProjectForm'
+import React from 'react'
+
 // 포트폴리오 항목 - 인덱스 연결 type
 export interface PorfolioItemsType {
-  portfolioItems: number
+  order: number
   mustHave: boolean
+  itemTitle: string
+  itemDesign: React.ElementType
+  itemForm: React.ElementType
 }
 
 // 포트폴리오 항목 Enum
@@ -32,35 +56,59 @@ export const PortfolioItemsStr = [
 
 export const PortfolioItems: PorfolioItemsType[] = [
   {
-    portfolioItems: PortfoiloItemsEnum.COVER,
+    order: PortfoiloItemsEnum.COVER,
     mustHave: true,
+    itemTitle: '표지',
+    itemDesign: CoverDesign,
+    itemForm: CoverForm,
   },
   {
-    portfolioItems: PortfoiloItemsEnum.INFO,
+    order: PortfoiloItemsEnum.INFO,
     mustHave: true,
+    itemTitle: '기본정보',
+    itemDesign: InfoDesigns,
+    itemForm: InfoForm,
   },
   {
-    portfolioItems: PortfoiloItemsEnum.EDUCATION,
+    order: PortfoiloItemsEnum.EDUCATION,
     mustHave: true,
+    itemTitle: '학력',
+    itemDesign: EducationDesign,
+    itemForm: EducationForm,
   },
   {
-    portfolioItems: PortfoiloItemsEnum.PROJECT,
+    order: PortfoiloItemsEnum.PROJECT,
     mustHave: false,
+    itemTitle: '프로젝트',
+    itemDesign: ProjectDesign,
+    itemForm: ProjectForm,
   },
   {
-    portfolioItems: PortfoiloItemsEnum.ACTIVITIES,
+    order: PortfoiloItemsEnum.ACTIVITIES,
     mustHave: false,
+    itemTitle: '대내외활동',
+    itemDesign: ActivitiesDesign,
+    itemForm: ActivitiesForm,
   },
   {
-    portfolioItems: PortfoiloItemsEnum.AWARDS,
+    order: PortfoiloItemsEnum.AWARDS,
     mustHave: false,
+    itemTitle: '수상내역',
+    itemDesign: AwardsDesign,
+    itemForm: AwardsForm,
   },
   {
-    portfolioItems: PortfoiloItemsEnum.CAREER,
+    order: PortfoiloItemsEnum.CAREER,
     mustHave: false,
+    itemTitle: '경력',
+    itemDesign: CareerDesign,
+    itemForm: CareerForm,
   },
   {
-    portfolioItems: PortfoiloItemsEnum.COVERLETTER,
+    order: PortfoiloItemsEnum.COVERLETTER,
     mustHave: false,
+    itemTitle: '자기소개서',
+    itemDesign: CoverletterDesign,
+    itemForm: CoverletterForm,
   },
 ]

--- a/front/src/store/state.ts
+++ b/front/src/store/state.ts
@@ -1,18 +1,1 @@
 import { atom } from 'recoil'
-
-// 타입스크립트 type import
-import { Menu } from './type'
-
-/**
- * 홈, 마이포트폴리오 페이지, 포트폴리오 생성 페이지 네브바 상태를 관리할 atom
- * default 는 홈으로, 타입에서 지정한 enum 을 이용한다
- *
- * atom 선언은 고유한 key 값 (atom 명과 동일하도록)과 default 값과 함께 선언한다
- * export 시켜서 사용할 컴포넌트에서 import 해서 사용하면 된다
- *
- * menuState atom 은 src/components/navBar 에서 사용한다
- */
-export const menuState = atom({
-  key: 'menuState',
-  default: Menu.HOME,
-})

--- a/front/src/store/type.ts
+++ b/front/src/store/type.ts
@@ -1,12 +1,1 @@
-// 네브바 이동에 따라 나타나는 색을 다르게 할 enum type
-export enum Menu {
-  HOME = 'red',
-  PORTFOLIO = 'blue',
-  MYPORTFOLIO = 'green',
-}
-
-// 로그인 시 아이디, 패스워드 type
-export interface LoginType {
-  id: string
-  pw: string
-}
+export default {}


### PR DESCRIPTION
## 📋 상세 구현 내용
- 포트폴리오 항목 바 - 디자인 - 입력 폼 순서 연결
- 포트폴리오 항목별 디자인 / 입력 폼 기본 코드 추가
- API 테스트 코드 제거

## 📌 전달 사항
- 특이 사항 없음

## 🪡 연관 이슈
- resolve : #63 
