### PR TITLE
[front] 포트폴리오 항목 입력폼 (프로젝트)

### DIFF
--- a/front/src/components/buttons/BtnSmallMedium.tsx
+++ b/front/src/components/buttons/BtnSmallMedium.tsx
@@ -1,9 +1,17 @@
 import React from 'react'
 
-function BtnSmallMedium() {
+function BtnSmallMedium({
+  BtnName,
+  doFunction,
+}: {
+  BtnName: string | number
+  doFunction(): void
+}) {
   return (
     <div>
-      <div>BtnSmallMedium</div>
+      <button type="button" onClick={() => doFunction()}>
+        {BtnName}
+      </button>
     </div>
   )
 }

--- a/front/src/components/buttons/BtnSmallShort.tsx
+++ b/front/src/components/buttons/BtnSmallShort.tsx
@@ -1,9 +1,17 @@
 import React from 'react'
 
-function BtnSmallShort() {
+function BtnSmallShort({
+  BtnName,
+  doFunction,
+}: {
+  BtnName: string | number
+  doFunction(): void
+}) {
   return (
     <div>
-      <div>BtnSmallShort</div>
+      <button type="button" onClick={() => doFunction()}>
+        {BtnName}
+      </button>
     </div>
   )
 }

--- a/front/src/pages/portfolio/components/itemforms/ProjectForm.tsx
+++ b/front/src/pages/portfolio/components/itemforms/ProjectForm.tsx
@@ -1,7 +1,178 @@
-import React from 'react'
+import BtnSmallShort from 'components/buttons/BtnSmallShort'
+import React, { useRef, useState } from 'react'
+import { useSetRecoilState } from 'recoil'
+import { pfProjectItemsState } from 'store/portfolioState'
+import { IProjectTypes } from 'store/portfolioType'
+import ItemContentDropdown from './itemformsitem/ItemContentDropdown'
+import ItemContentImgUpload from './itemformsitem/ItemContentImgUpload'
+import ItemContentInputShort from './itemformsitem/ItemContentInputShort'
+import ItemContentTextareaLong from './itemformsitem/ItemContentTextareaLong'
+import ItemContentTextareaShort from './itemformsitem/ItemContentTextareaShort'
 
 function ProjectForm() {
-  return <div>프로젝트 입력 폼</div>
+  // 프로젝트 관련 저장할 state
+  const [projectName, setProjectName] = useState<string>('')
+  const [projectDescript, setProjectDescript] = useState<string>('')
+  const [getSelected, setGetSelected] = useState<string | number>(1)
+  const [projectWork, setProjectWork] = useState<string>('')
+  const [projectLink, setProjectLink] = useState<string>('')
+  // 여러 개 추가해야 하는 경우 state (링크, 이미지)
+  const [projectLinks, setProjectLinks] = useState<string[]>([])
+  const [projectAchieve, setProjectAchieve] = useState<string>('')
+  const [projectRemind, setProjectRemind] = useState<string>('')
+  const [imageUpload, setImageUpload] = useState<string>('')
+  const imageRef = useRef<HTMLInputElement | null>(null)
+
+  // 프로젝트 항목이 담긴 state
+  const ProjectItems = {
+    ProjectName: projectName,
+    ProjectStartDate: '',
+    ProjectEndDate: '',
+    ProjectDescript: projectDescript,
+    ProjectPplNum: getSelected,
+    ProjectWork: projectWork,
+    ProjectLink: projectLinks,
+    ProjectAchieve: projectAchieve,
+    ProjectRemind: projectRemind,
+  }
+
+  // 프로젝트 항목이 담긴 atom
+  const setPfProjectItems = useSetRecoilState(pfProjectItemsState)
+
+  // atom 에 저장하는 function
+  const SaveProjectForm = (items: IProjectTypes) => {
+    setPfProjectItems(items)
+  }
+  // 초기화 버튼
+  const ResetProjectForm = () => {
+    setProjectName('')
+    setProjectDescript('')
+    setGetSelected(1)
+    setProjectWork('')
+    setProjectLink('')
+    setProjectLinks([])
+    setProjectAchieve('')
+    setProjectRemind('')
+    setImageUpload('')
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'flex' }}>
+        <BtnSmallShort
+          BtnName="저장"
+          doFunction={() => SaveProjectForm(ProjectItems)}
+        />
+        <BtnSmallShort BtnName="초기화" doFunction={() => ResetProjectForm()} />
+      </div>
+      <div style={{ display: 'flex' }}>
+        프로젝트명{' '}
+        <ItemContentInputShort
+          placeholder="프로젝트 이름을 입력하세요."
+          content={projectName}
+          setFunction={setProjectName}
+        />
+      </div>
+      <div style={{ display: 'flex' }}>시작 종료</div>
+      <div style={{ display: 'flex' }}>
+        설명{' '}
+        <ItemContentTextareaShort
+          placeholder="프로젝트에 대한 설명을 적어주세요. (100 자 이내)"
+          content={projectDescript}
+          setFunction={setProjectDescript}
+        />
+      </div>
+      <div>
+        팀원 수{' '}
+        <ItemContentDropdown
+          DropdownContent={[1, 2, 3, 4, 5, 6, 7, 8, 9, '10 명 이상']}
+          setGetSelected={setGetSelected}
+          getSelected={getSelected}
+        />
+      </div>
+      <div style={{ display: 'flex' }}>
+        담당 업무{' '}
+        <ItemContentTextareaShort
+          placeholder="담당 업무를 입력해 주세요"
+          content={projectWork}
+          setFunction={setProjectWork}
+        />
+      </div>
+      <div>
+        <div style={{ display: 'flex' }}>
+          관련 링크{' '}
+          <ItemContentInputShort
+            placeholder="프로젝트 관련 링크를 입력하세요. (최대 3개)"
+            content={projectLink}
+            setFunction={setProjectLink}
+          />
+          <BtnSmallShort
+            BtnName="추가"
+            doFunction={() => {
+              setProjectLinks([projectLink, ...projectLinks])
+              setProjectLink('')
+            }}
+          />
+        </div>
+        {projectLinks.map((item) => (
+          <div key={item} style={{ display: 'flex' }}>
+            <button
+              type="button"
+              onClick={() => window.open(item)}
+              aria-label="url"
+            >
+              {item}
+            </button>
+            <BtnSmallShort
+              BtnName="삭제"
+              doFunction={() => {
+                const deleteProjectLink = projectLinks.filter(
+                  (data) => data !== item
+                )
+                setProjectLinks(deleteProjectLink)
+              }}
+            />
+          </div>
+        ))}
+      </div>
+      <div style={{ display: 'flex' }}>
+        성과{' '}
+        <ItemContentTextareaLong
+          placeholder="프로젝트로 얻은 성과를 적어주세요. (300 자 이내)"
+          content={projectAchieve}
+          setFunction={setProjectAchieve}
+        />
+      </div>
+      <div style={{ display: 'flex' }}>
+        회고{' '}
+        <ItemContentTextareaLong
+          placeholder="프로젝트 회고를 적어주세요. (1000 자 이내)"
+          content={projectRemind}
+          setFunction={setProjectRemind}
+        />
+      </div>
+      <div style={{ display: 'flex' }}>
+        대표 사진{' '}
+        <ItemContentImgUpload
+          imageRef={imageRef}
+          setImageState={setImageUpload}
+        />
+        <div>
+          {imageUpload && (
+            <div>
+              <img src={imageUpload} alt="이미지 미리보기" />
+              <BtnSmallShort
+                BtnName="삭제"
+                doFunction={() => {
+                  setImageUpload('')
+                }}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export default ProjectForm

--- a/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentDropdown.tsx
+++ b/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentDropdown.tsx
@@ -1,1 +1,45 @@
-export default {}
+import BtnSmallShort from 'components/buttons/BtnSmallShort'
+import React, { useState } from 'react'
+
+// 드랍다운 내용과 placeholder props 로 받기
+function ItemContentDropdown({
+  DropdownContent,
+  setGetSelected,
+  getSelected,
+}: {
+  DropdownContent: Array<number | string>
+  setGetSelected(value: number | string): void
+  getSelected: number | string
+}) {
+  // 드랍다운 visibility 여부와 선택된 항목 표시하기
+  const [dropdownShow, setDropdownShow] = useState(false)
+
+  const ShowDropdown = (value: boolean) => {
+    setDropdownShow(!dropdownShow)
+    return value
+  }
+
+  return (
+    <div>
+      <BtnSmallShort
+        BtnName={getSelected}
+        doFunction={() => ShowDropdown(true)}
+      />
+      {dropdownShow &&
+        DropdownContent.map((item) => (
+          <div
+            key={item}
+            onClick={() => {
+              setDropdownShow(!dropdownShow)
+              setGetSelected(item)
+            }}
+            role="presentation"
+          >
+            {item}
+          </div>
+        ))}
+    </div>
+  )
+}
+
+export default ItemContentDropdown

--- a/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentImgUpload.tsx
+++ b/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentImgUpload.tsx
@@ -1,1 +1,39 @@
-export default {}
+import React, { useCallback } from 'react'
+
+function ItemContentImgUpload({
+  imageRef,
+  setImageState,
+}: {
+  imageRef: React.MutableRefObject<HTMLInputElement | null>
+  setImageState(value: string): void
+}) {
+  // 이미지 업로드와 미리보기
+  const doUploadImage = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (!e.target.files) {
+        return
+      }
+      const image = e.target.files[0]
+      const CurrentImgUrl = URL.createObjectURL(image)
+
+      const formData = new FormData()
+      formData.append('image', image)
+
+      setImageState(CurrentImgUrl)
+    },
+    []
+  )
+
+  return (
+    <div>
+      <input
+        type="file"
+        ref={imageRef}
+        accept="image/jpg, image/png, image/jpeg, image/gif"
+        onChange={doUploadImage}
+      />
+    </div>
+  )
+}
+
+export default ItemContentImgUpload

--- a/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentInputShort.tsx
+++ b/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentInputShort.tsx
@@ -1,1 +1,25 @@
-export default {}
+import React from 'react'
+
+function ItemContentInputShort({
+  placeholder,
+  content,
+  setFunction,
+}: {
+  placeholder: string
+  content: string
+  setFunction(value: string): void
+}) {
+  return (
+    <div>
+      <input
+        placeholder={placeholder}
+        value={content}
+        onChange={(e) => {
+          setFunction(e.target.value)
+        }}
+      />
+    </div>
+  )
+}
+
+export default ItemContentInputShort

--- a/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentTextareaLong.tsx
+++ b/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentTextareaLong.tsx
@@ -1,1 +1,25 @@
-export default {}
+import React from 'react'
+
+function ItemContentTextareaLong({
+  placeholder,
+  content,
+  setFunction,
+}: {
+  placeholder: string
+  content: string
+  setFunction(value: string): void
+}) {
+  return (
+    <div>
+      <textarea
+        placeholder={placeholder}
+        value={content}
+        onChange={(e) => {
+          setFunction(e.target.value)
+        }}
+      />
+    </div>
+  )
+}
+
+export default ItemContentTextareaLong

--- a/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentTextareaShort.tsx
+++ b/front/src/pages/portfolio/components/itemforms/itemformsitem/ItemContentTextareaShort.tsx
@@ -1,1 +1,25 @@
-export default {}
+import React from 'react'
+
+function ItemContentTextareaShort({
+  placeholder,
+  content,
+  setFunction,
+}: {
+  placeholder: string
+  content: string
+  setFunction(value: string): void
+}) {
+  return (
+    <div>
+      <textarea
+        placeholder={placeholder}
+        value={content}
+        onChange={(e) => {
+          setFunction(e.target.value)
+        }}
+      />
+    </div>
+  )
+}
+
+export default ItemContentTextareaShort

--- a/front/src/store/portfolioState.ts
+++ b/front/src/store/portfolioState.ts
@@ -1,9 +1,29 @@
-import { atom, selector } from 'recoil'
+import { atom } from 'recoil'
 
-import { PortfolioItems, PorfolioItemsType } from './portfolioType'
+import {
+  PortfolioItems,
+  PorfolioItemsType,
+  IProjectTypes,
+} from './portfolioType'
 
 // 포트폴리오 항목 순서 state
 export const pfItemsOrderState = atom<Array<PorfolioItemsType>>({
   key: 'pfItemsOrderState',
   default: PortfolioItems,
+})
+
+// 포트폴리오 중 프로젝트 항목 state
+export const pfProjectItemsState = atom<IProjectTypes>({
+  key: 'pfProjectItemsState',
+  default: {
+    ProjectName: '',
+    ProjectStartDate: '',
+    ProjectEndDate: '',
+    ProjectDescript: '',
+    ProjectPplNum: 1,
+    ProjectWork: '',
+    ProjectLink: [],
+    ProjectAchieve: '',
+    ProjectRemind: '',
+  },
 })

--- a/front/src/store/portfolioType.ts
+++ b/front/src/store/portfolioType.ts
@@ -112,3 +112,17 @@ export const PortfolioItems: PorfolioItemsType[] = [
     itemForm: CoverletterForm,
   },
 ]
+
+// 포트폴리오 항목 type ===============================
+// 프로젝트 type
+export interface IProjectTypes {
+  ProjectName: string
+  ProjectStartDate: string
+  ProjectEndDate: string
+  ProjectDescript: string
+  ProjectPplNum: number | string
+  ProjectWork: string
+  ProjectLink: Array<string>
+  ProjectAchieve: string
+  ProjectRemind: string
+}


### PR DESCRIPTION
## 📋 상세 구현 내용
<img width="417" alt="image" src="https://user-images.githubusercontent.com/115437273/209453532-8af791d9-fb09-4b16-9959-c75f79d2d6f0.png">

- 포트폴리오 항목 중 프로젝트 입력 폼 구현
- 공통 버튼 컴포넌트 생성, props 를 통해 함수, 변수 전달 가능하도록 설계
- itemformsitem 일부 생성, 드랍 다운 / input / textarea / imageUpload 도 마찬가지로 props 가능하도록 설계 
- 프로젝트 입력 폼 관련 atom / type 지정
- [To do] 이미지 여러 장 업로드

## 📌 전달 사항
- 입력 폼에 입력 시 useState 를 통해 임시로 상태 값을 저장해둔 후 최종 저장 시 atom 을 변경
- atom 에 저장된 값을 POST 요청을 통해 서버에 저장
- 이미지 파일 업로드 시 초기화 되지 않는 문제 해결 필요

## 🪡 연관 이슈
- resolve : #37 
- related to : #43 #45 
